### PR TITLE
Update devcontainer.json

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,22 +1,28 @@
 // For format details, see https://aka.ms/devcontainer.json. For config options, see the
 // README at: https://github.com/devcontainers/templates/tree/main/src/python
 {
-	"name": "Python 3",
- 
-    	"initializeCommand": "make compile_frontend"
+  "name": "GPT-Code-UI",
+  // Or use a Dockerfile or Docker Compose file. More info: https://containers.dev/guide/dockerfile
+  "image": "mcr.microsoft.com/devcontainers/python:0-3.11",
+  // Features to add to the dev container. More info: https://containers.dev/features.
+  "features": {
+    "ghcr.io/jungaretti/features/make:1": {},
+    "ghcr.io/akhildevelops/devcontainer-features/pip:0": {},
+    "ghcr.io/devcontainers/features/node:1": {}
+  },
 
-	// Features to add to the dev container. More info: https://containers.dev/features.
-	// "features": {},
+  // Use 'forwardPorts' to make a list of ports inside the container available locally.
+  "forwardPorts": [8080],
 
-	// Use 'forwardPorts' to make a list of ports inside the container available locally.
-	// "forwardPorts": [],
+  "postCreateCommand": "make compile_frontend",
+  "postStartCommand": "pip3 install --user gpt-code-ui",
+  "postAttachCommand": "gptcode",
 
-	// Use 'postCreateCommand' to run commands after the container is created.
-	// "postCreateCommand": "pip3 install --user -r requirements.txt",
+  // Configure tool-specific properties.
+  // "customizations": {},
 
-	// Configure tool-specific properties.
-	// "customizations": {},
-
-	// Uncomment to connect as root instead. More info: https://aka.ms/dev-containers-non-root.
-	// "remoteUser": "root"
+  // Uncomment to connect as root instead. More info: https://aka.ms/dev-containers-non-root.
+  // Is there a way to allow the make command to execute without being root in the container?
+  // An error occurs when attempting to rsync as anything other than root user.
+  "remoteUser": "root"
 }


### PR DESCRIPTION
This PR allows for the devcontainer.json file to build and run the application in a local container. The dev container forwards the Web GUI from port 8080 to the VSCode host. You can access the application ports from the `Ports` tab above the VSCode terminal after rebuilding and reopening the repo in a dev container.

Closes: #21 