### PR TITLE
Enhance support for Azure OpenAI

### DIFF
--- a/.env.azure-example
+++ b/.env.azure-example
@@ -1,0 +1,8 @@
+OPENAI_API_KEY=XXXX
+OPENAI_API_TYPE=azure
+OPENAI_BASE_URL=https://your-resource-name.openai.azure.com
+OPENAI_API_VERSION=2023-03-15-preview
+AZURE_OPENAI_DEPLOYMENT=your-model-deployment-name
+API_PORT=5010
+WEB_PORT=8080
+SNAKEMQ_PORT=8765

--- a/README.md
+++ b/README.md
@@ -37,6 +37,9 @@ Set `OPENAI_BASE_URL` to change the OpenAI API endpoint that's being used (note 
 
 You can use the `.env.example` in the repository (make sure you `git clone` the repo to get the file first).
 
+For Azure OpenAI Services, there are also other configurable variables like deployment name. See `.env.azure-example` for more information.
+Note that model selection on the UI is currently not supported for Azure OpenAI Services.
+
 ```
 cp .env.example .env
 vim .env


### PR DESCRIPTION
With the suggested changes, Azure OpenAI Chat API is supported in a basic way.

Note that there is still no support on the front-end. The model selection on the front-end won't have an effect for Azure OpenAI. That is defined by the deployment name in the environment variables only.

As a next step the users can be enabled to provide the azure deployment name on the UI if the provider is Azure.
