### PR TITLE
fix 'Expected 3 values to unpack but got 2' when case the API call fails

### DIFF
--- a/gpt_code_ui/webapp/main.py
+++ b/gpt_code_ui/webapp/main.py
@@ -130,7 +130,7 @@ async def get_code(user_prompt, user_openai_key=None, model="gpt-3.5-turbo"):
             headers=headers,
         )
     else:
-        return "Error: Invalid OPENAI_PROVIDER", 500
+        return None, "Error: Invalid OPENAI_PROVIDER", 500
 
 
     def extract_code(text):
@@ -153,7 +153,7 @@ async def get_code(user_prompt, user_openai_key=None, model="gpt-3.5-turbo"):
 
 
     if response.status_code != 200:
-        return "Error: " + response.text, 500
+        return None, "Error: " + response.text, 500
 
     content = response.json()["choices"][0]["message"]["content"]
     return extract_code(content), extract_non_code(content), 200


### PR DESCRIPTION
The function is expected to return 3 values, but in case of a failure it only returns 2, which leads to failures being invisible in the frontend and the application being seemingly stuck.