### PR TITLE
Add some information in the data to the prompt

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -155,9 +155,9 @@ function App() {
     });
   }
 
-  function completeUpload(filename: string) {
+  function completeUpload(message: string) {
     addMessage({
-      text: `File ${filename} was uploaded successfully.`,
+      text: message,
       type: "message",
       role: "system",
     });
@@ -171,7 +171,7 @@ function App() {
         "Content-Type": "application/json",
       },
       body: JSON.stringify({
-        prompt: `File ${filename} was uploaded successfully.`,
+        prompt: message,
       }),
     })
       .then(() => {})

--- a/frontend/src/components/Input.tsx
+++ b/frontend/src/components/Input.tsx
@@ -43,11 +43,13 @@ export default function Input(props: { onSendMessage: any, onStartUpload: any, o
           body: formData,
         });
 
-        props.onCompletedUpload(file.name);
-
         if (!response.ok) {
           throw new Error("Network response was not ok");
         }
+
+        const json = await response.json();
+        props.onCompletedUpload(json["message"]);
+
       } catch (error) {
         console.error("Error:", error);
       }


### PR DESCRIPTION
Before this change, when asking to create code for analyzing column values e.g., in an .xlsx-File, GPT often just guessed the relevant column names and thus most of the time, the generated code did not run with the actual data.

With this change, we try to open the uploaded file with pandas, read the column names and also inject them into the prompt. This considerably reduces failure rate of the generated code.