### PR TITLE
chore: Fix Name of Environment Variable for API Base Path

### DIFF
--- a/.env.azure-example
+++ b/.env.azure-example
@@ -1,6 +1,6 @@
 OPENAI_API_KEY=XXXX
 OPENAI_API_TYPE=azure
-OPENAI_BASE_URL=https://your-resource-name.openai.azure.com
+OPENAI_API_BASE=https://your-resource-name.openai.azure.com
 OPENAI_API_VERSION=2023-03-15-preview
 # OPENAI_EXTRA_HEADERS={"key": "value"}
 AZURE_OPENAI_DEPLOYMENTS=[{"displayName": "GPT-3.5", "name": "your-gpt-3.5-deployment"}, {"displayName": "GPT-4", "name": "your-gpt-4-deployment"}]

--- a/.env.example
+++ b/.env.example
@@ -1,6 +1,6 @@
 OPENAI_API_KEY=sk-XXXX
 OPENAI_API_TYPE=open_ai
-OPENAI_BASE_URL=https://api.openai.com/v1
+OPENAI_API_BASE=https://api.openai.com/v1
 OPENAI_API_VERSION=2023-03-15-preview
 # OPENAI_EXTRA_HEADERS={"key": "value"}
 OPENAI_MODELS=[{"displayName": "GPT-3.5", "name": "gpt-3.5-turbo"}, {"displayName": "GPT-4", "name": "gpt-4"}]


### PR DESCRIPTION
With a previous change (99a6ba82d504728e41ea6372e342fddf99671039), these variables are read by the openai package automagically and thus must have the correct name.

See https://github.com/openai/openai-python/blob/b82a3f7e4c462a8a10fa445193301a3cefef9a4a/openai/__init__.py#L49