### PR TITLE
chore: Only Try to Run Code if Any Code Has Been Found

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -134,8 +134,12 @@ function App() {
         return;
       }
       
-      submitCode(code);
-      setWaitingForSystem(WaitingStates.RunningCode);
+      if (!!code) {
+        submitCode(code);
+        setWaitingForSystem(WaitingStates.RunningCode);
+      } else {
+        setWaitingForSystem(WaitingStates.Idle);
+      }
     } catch (error) {
       console.error(
         "There has been a problem with your fetch operation:",


### PR DESCRIPTION
Sometimes, the LLM just answers something along the lines of "In need more explanation", "I cannot do that", etc.

Then, no code block is embedded in the answer and `code` is `None` in Python. This change prevents attempting to execute empty code, which leads to some non-intuitive error message when posting the command to snakemq.