### PR TITLE
feat: add MiniMax as a first-class LLM provider (M3 default)

### DIFF
--- a/.env.minimax-example
+++ b/.env.minimax-example
@@ -3,7 +3,7 @@ OPENAI_API_TYPE=minimax
 # Optional: override the default MiniMax API base URL
 # OPENAI_API_BASE=https://api.minimax.io/v1
 # Optional: customize available models (JSON array)
-# MINIMAX_MODELS=[{"displayName": "MiniMax-M2.7", "name": "MiniMax-M2.7"}, {"displayName": "MiniMax-M2.7-highspeed", "name": "MiniMax-M2.7-highspeed"}]
+# MINIMAX_MODELS=[{"displayName": "MiniMax-M3", "name": "MiniMax-M3"}, {"displayName": "MiniMax-M2.7", "name": "MiniMax-M2.7"}, {"displayName": "MiniMax-M2.7-highspeed", "name": "MiniMax-M2.7-highspeed"}]
 # OPENAI_EXTRA_HEADERS={"key": "value"}
 # OPENAI_API_LOGLEVEL=debug
 API_PORT=5010

--- a/.env.minimax-example
+++ b/.env.minimax-example
@@ -1,0 +1,11 @@
+MINIMAX_API_KEY=your-minimax-api-key
+OPENAI_API_TYPE=minimax
+# Optional: override the default MiniMax API base URL
+# OPENAI_API_BASE=https://api.minimax.io/v1
+# Optional: customize available models (JSON array)
+# MINIMAX_MODELS=[{"displayName": "MiniMax-M2.7", "name": "MiniMax-M2.7"}, {"displayName": "MiniMax-M2.7-highspeed", "name": "MiniMax-M2.7-highspeed"}]
+# OPENAI_EXTRA_HEADERS={"key": "value"}
+# OPENAI_API_LOGLEVEL=debug
+API_PORT=5010
+WEB_PORT=8080
+SNAKEMQ_PORT=8765

--- a/README.md
+++ b/README.md
@@ -50,6 +50,11 @@ You can use the `.env.example` in the repository (make sure you `git clone` the 
 For Azure OpenAI Services, there are also other configurable variables like deployment name. See `.env.azure-example` for more information.
 Note that model selection on the UI is currently not supported for Azure OpenAI Services.
 
+### Using MiniMax AI
+[MiniMax](https://www.minimaxi.com/) models (M2.7, M2.7-highspeed) are supported via the OpenAI-compatible API. Set `OPENAI_API_TYPE=minimax` and provide your `MINIMAX_API_KEY`. See `.env.minimax-example` for a complete configuration template.
+
+MiniMax can also be auto-detected: if `MINIMAX_API_KEY` is set and `OPENAI_API_KEY` is not, MiniMax is used automatically.
+
 ```
 cp .env.example .env
 vim .env

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ For Azure OpenAI Services, there are also other configurable variables like depl
 Note that model selection on the UI is currently not supported for Azure OpenAI Services.
 
 ### Using MiniMax AI
-[MiniMax](https://www.minimaxi.com/) models (M2.7, M2.7-highspeed) are supported via the OpenAI-compatible API. Set `OPENAI_API_TYPE=minimax` and provide your `MINIMAX_API_KEY`. See `.env.minimax-example` for a complete configuration template.
+[MiniMax](https://www.minimaxi.com/) models (M3, M2.7, M2.7-highspeed) are supported via the OpenAI-compatible API. Set `OPENAI_API_TYPE=minimax` and provide your `MINIMAX_API_KEY`. See `.env.minimax-example` for a complete configuration template. The default model is `MiniMax-M3` (512K context, up to 128K output, supports image input).
 
 MiniMax can also be auto-detected: if `MINIMAX_API_KEY` is set and `OPENAI_API_KEY` is not, MiniMax is used automatically.
 

--- a/gpt_code_ui/webapp/main.py
+++ b/gpt_code_ui/webapp/main.py
@@ -54,7 +54,7 @@ elif PROVIDER == "azure":
     except KeyError as e:
         raise RuntimeError('AZURE_OPENAI_DEPLOYMENTS environment variable not set') from e
 elif PROVIDER == "minimax":
-    AVAILABLE_MODELS = json.loads(os.environ.get("MINIMAX_MODELS", '''[{"displayName": "MiniMax-M2.7", "name": "MiniMax-M2.7"}, {"displayName": "MiniMax-M2.7-highspeed", "name": "MiniMax-M2.7-highspeed"}]'''))
+    AVAILABLE_MODELS = json.loads(os.environ.get("MINIMAX_MODELS", '''[{"displayName": "MiniMax-M3", "name": "MiniMax-M3"}, {"displayName": "MiniMax-M2.7", "name": "MiniMax-M2.7"}, {"displayName": "MiniMax-M2.7-highspeed", "name": "MiniMax-M2.7-highspeed"}]'''))
 else:
     raise ValueError(f'Invalid OPENAI_API_TYPE: {PROVIDER}')
 

--- a/gpt_code_ui/webapp/main.py
+++ b/gpt_code_ui/webapp/main.py
@@ -19,19 +19,44 @@ from gpt_code_ui.kernel_program.main import APP_PORT as KERNEL_APP_PORT
 
 load_dotenv('.env')
 
+# Detect provider type: supports "open_ai", "azure", and "minimax"
+# MiniMax can be selected via OPENAI_API_TYPE=minimax or auto-detected
+# when MINIMAX_API_KEY is set without OPENAI_API_KEY.
+PROVIDER = os.environ.get("OPENAI_API_TYPE", "").strip()
+if not PROVIDER:
+    if os.environ.get("MINIMAX_API_KEY") and not os.environ.get("OPENAI_API_KEY"):
+        PROVIDER = "minimax"
+    else:
+        PROVIDER = openai.api_type or "open_ai"
+
+if PROVIDER == "minimax":
+    # MiniMax uses an OpenAI-compatible API, so we configure the openai
+    # library to point at the MiniMax endpoint.
+    openai.api_type = "open_ai"
+    openai.api_base = os.environ.get(
+        "OPENAI_API_BASE",
+        "https://api.minimax.io/v1"
+    )
+    openai.api_key = os.environ.get(
+        "MINIMAX_API_KEY",
+        os.environ.get("OPENAI_API_KEY")
+    )
+
 openai.api_version = os.environ.get("OPENAI_API_VERSION")
 openai.log = os.getenv("OPENAI_API_LOGLEVEL")
 OPENAI_EXTRA_HEADERS = json.loads(os.environ.get("OPENAI_EXTRA_HEADERS", "{}"))
 
-if openai.api_type == "open_ai":
+if PROVIDER == "open_ai":
     AVAILABLE_MODELS = json.loads(os.environ.get("OPENAI_MODELS", '''[{"displayName": "GPT-3.5", "name": "gpt-3.5-turbo"}, {"displayName": "GPT-4", "name": "gpt-4"}]'''))
-elif openai.api_type == "azure":
+elif PROVIDER == "azure":
     try:
         AVAILABLE_MODELS = json.loads(os.environ["AZURE_OPENAI_DEPLOYMENTS"])
     except KeyError as e:
         raise RuntimeError('AZURE_OPENAI_DEPLOYMENTS environment variable not set') from e
+elif PROVIDER == "minimax":
+    AVAILABLE_MODELS = json.loads(os.environ.get("MINIMAX_MODELS", '''[{"displayName": "MiniMax-M2.7", "name": "MiniMax-M2.7"}, {"displayName": "MiniMax-M2.7-highspeed", "name": "MiniMax-M2.7-highspeed"}]'''))
 else:
-    raise ValueError(f'Invalid OPENAI_API_TYPE: {openai.api_type}')
+    raise ValueError(f'Invalid OPENAI_API_TYPE: {PROVIDER}')
 
 UPLOAD_FOLDER = 'workspace/'
 os.makedirs(UPLOAD_FOLDER, exist_ok=True)
@@ -126,8 +151,13 @@ async def get_code(user_prompt, user_openai_key=None, model="gpt-3.5-turbo"):
     if user_openai_key:
         openai.api_key = user_openai_key
 
+    temperature = 0.7
+    # MiniMax requires temperature in range (0, 1].
+    if PROVIDER == "minimax":
+        temperature = max(0.01, min(temperature, 1.0))
+
     arguments = dict(
-        temperature=0.7,
+        temperature=temperature,
         headers=OPENAI_EXTRA_HEADERS,
         messages=[
             # {"role": "system", "content": system},
@@ -135,12 +165,12 @@ async def get_code(user_prompt, user_openai_key=None, model="gpt-3.5-turbo"):
         ]
     )
 
-    if openai.api_type == 'open_ai':
+    if PROVIDER in ('open_ai', 'minimax'):
         arguments["model"] = model
-    elif openai.api_type == 'azure':
+    elif PROVIDER == 'azure':
         arguments["deployment_id"] = model
     else:
-        return None, f"Error: Invalid OPENAI_PROVIDER: {openai.api_type}", 500
+        return None, f"Error: Invalid OPENAI_PROVIDER: {PROVIDER}", 500
 
     try:
         result_GPT = openai.ChatCompletion.create(**arguments)

--- a/tests/test_minimax_integration.py
+++ b/tests/test_minimax_integration.py
@@ -1,0 +1,76 @@
+"""Integration tests for MiniMax provider support.
+
+These tests verify the MiniMax API integration end-to-end.
+They require MINIMAX_API_KEY to be set in the environment and
+are skipped otherwise.
+"""
+
+import asyncio
+import json
+import os
+import importlib
+import unittest
+from unittest.mock import patch, MagicMock
+
+MINIMAX_API_KEY = os.environ.get("MINIMAX_API_KEY")
+SKIP_REASON = "MINIMAX_API_KEY not set; skipping integration tests"
+
+
+def _reload_main_with_minimax():
+    """Reload main module configured for MiniMax."""
+    env = os.environ.copy()
+    env["OPENAI_API_TYPE"] = "minimax"
+    env["MINIMAX_API_KEY"] = MINIMAX_API_KEY
+    env.pop("OPENAI_API_BASE", None)
+    env.pop("MINIMAX_MODELS", None)
+
+    with patch.dict(os.environ, env):
+        with patch.dict("sys.modules", {
+            "gpt_code_ui.kernel_program.main": MagicMock(APP_PORT=5010),
+            "pandas": MagicMock(),
+        }):
+            import gpt_code_ui.webapp.main as main_mod
+            importlib.reload(main_mod)
+            return main_mod
+
+
+@unittest.skipUnless(MINIMAX_API_KEY, SKIP_REASON)
+class TestMiniMaxLiveAPI(unittest.TestCase):
+    """Integration tests that call the real MiniMax API."""
+
+    def test_generate_code_with_minimax_m27(self):
+        """MiniMax M2.7 generates Python code from a prompt."""
+        mod = _reload_main_with_minimax()
+        loop = asyncio.new_event_loop()
+        code, text, status = loop.run_until_complete(
+            mod.get_code("Print 'hello world'", model="MiniMax-M2.7")
+        )
+        loop.close()
+
+        self.assertEqual(status, 200)
+        self.assertIsNotNone(code)
+        self.assertIn("hello", code.lower())
+
+    def test_generate_code_with_minimax_m27_highspeed(self):
+        """MiniMax M2.7-highspeed generates Python code from a prompt."""
+        mod = _reload_main_with_minimax()
+        loop = asyncio.new_event_loop()
+        code, text, status = loop.run_until_complete(
+            mod.get_code("Print the number 42", model="MiniMax-M2.7-highspeed")
+        )
+        loop.close()
+
+        self.assertEqual(status, 200)
+        self.assertIsNotNone(code)
+        self.assertIn("42", code)
+
+    def test_models_endpoint_returns_minimax_models(self):
+        """The /models endpoint returns MiniMax models when configured."""
+        mod = _reload_main_with_minimax()
+        model_names = [m["name"] for m in mod.AVAILABLE_MODELS]
+        self.assertIn("MiniMax-M2.7", model_names)
+        self.assertIn("MiniMax-M2.7-highspeed", model_names)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_minimax_integration.py
+++ b/tests/test_minimax_integration.py
@@ -38,6 +38,19 @@ def _reload_main_with_minimax():
 class TestMiniMaxLiveAPI(unittest.TestCase):
     """Integration tests that call the real MiniMax API."""
 
+    def test_generate_code_with_minimax_m3(self):
+        """MiniMax M3 generates Python code from a prompt."""
+        mod = _reload_main_with_minimax()
+        loop = asyncio.new_event_loop()
+        code, text, status = loop.run_until_complete(
+            mod.get_code("Print 'hello world'", model="MiniMax-M3")
+        )
+        loop.close()
+
+        self.assertEqual(status, 200)
+        self.assertIsNotNone(code)
+        self.assertIn("hello", code.lower())
+
     def test_generate_code_with_minimax_m27(self):
         """MiniMax M2.7 generates Python code from a prompt."""
         mod = _reload_main_with_minimax()
@@ -68,8 +81,11 @@ class TestMiniMaxLiveAPI(unittest.TestCase):
         """The /models endpoint returns MiniMax models when configured."""
         mod = _reload_main_with_minimax()
         model_names = [m["name"] for m in mod.AVAILABLE_MODELS]
+        self.assertIn("MiniMax-M3", model_names)
         self.assertIn("MiniMax-M2.7", model_names)
         self.assertIn("MiniMax-M2.7-highspeed", model_names)
+        # M3 should be the default (first in list)
+        self.assertEqual(model_names[0], "MiniMax-M3")
 
 
 if __name__ == "__main__":

--- a/tests/test_minimax_provider.py
+++ b/tests/test_minimax_provider.py
@@ -1,0 +1,280 @@
+"""Unit tests for MiniMax provider support in gpt-code-ui."""
+
+import json
+import os
+import importlib
+import unittest
+from unittest.mock import patch, MagicMock
+
+
+class TestProviderDetection(unittest.TestCase):
+    """Test that the PROVIDER variable is set correctly based on env vars."""
+
+    def _reload_main(self):
+        """Reload the webapp main module to pick up env var changes."""
+        # We need to mock heavy imports that fail without a running kernel
+        with patch.dict("sys.modules", {
+            "gpt_code_ui.kernel_program.main": MagicMock(APP_PORT=5010),
+            "pandas": MagicMock(),
+        }):
+            import gpt_code_ui.webapp.main as main_mod
+            importlib.reload(main_mod)
+            return main_mod
+
+    @patch.dict(os.environ, {
+        "OPENAI_API_TYPE": "minimax",
+        "MINIMAX_API_KEY": "test-minimax-key",
+    }, clear=False)
+    def test_explicit_minimax_provider(self):
+        """OPENAI_API_TYPE=minimax selects MiniMax provider."""
+        mod = self._reload_main()
+        self.assertEqual(mod.PROVIDER, "minimax")
+
+    @patch.dict(os.environ, {
+        "OPENAI_API_TYPE": "",
+        "MINIMAX_API_KEY": "test-minimax-key",
+    }, clear=False)
+    def test_auto_detect_minimax_when_only_minimax_key(self):
+        """MiniMax is auto-detected when MINIMAX_API_KEY is set and OPENAI_API_KEY is not."""
+        # Remove OPENAI_API_KEY if present
+        env = os.environ.copy()
+        env.pop("OPENAI_API_KEY", None)
+        env["OPENAI_API_TYPE"] = ""
+        env["MINIMAX_API_KEY"] = "test-minimax-key"
+        with patch.dict(os.environ, env, clear=True):
+            mod = self._reload_main()
+            self.assertEqual(mod.PROVIDER, "minimax")
+
+    @patch.dict(os.environ, {
+        "OPENAI_API_TYPE": "open_ai",
+        "OPENAI_API_KEY": "sk-test",
+    }, clear=False)
+    def test_explicit_openai_provider(self):
+        """OPENAI_API_TYPE=open_ai selects OpenAI provider."""
+        mod = self._reload_main()
+        self.assertEqual(mod.PROVIDER, "open_ai")
+
+
+class TestMiniMaxModels(unittest.TestCase):
+    """Test that AVAILABLE_MODELS is populated correctly for MiniMax."""
+
+    def _reload_main(self):
+        with patch.dict("sys.modules", {
+            "gpt_code_ui.kernel_program.main": MagicMock(APP_PORT=5010),
+            "pandas": MagicMock(),
+        }):
+            import gpt_code_ui.webapp.main as main_mod
+            importlib.reload(main_mod)
+            return main_mod
+
+    @patch.dict(os.environ, {
+        "OPENAI_API_TYPE": "minimax",
+        "MINIMAX_API_KEY": "test-key",
+    }, clear=False)
+    def test_default_minimax_models(self):
+        """Default MiniMax models include M2.7 and M2.7-highspeed."""
+        # Remove custom MINIMAX_MODELS if set
+        env = os.environ.copy()
+        env.pop("MINIMAX_MODELS", None)
+        env["OPENAI_API_TYPE"] = "minimax"
+        env["MINIMAX_API_KEY"] = "test-key"
+        with patch.dict(os.environ, env):
+            mod = self._reload_main()
+            model_names = [m["name"] for m in mod.AVAILABLE_MODELS]
+            self.assertIn("MiniMax-M2.7", model_names)
+            self.assertIn("MiniMax-M2.7-highspeed", model_names)
+
+    @patch.dict(os.environ, {
+        "OPENAI_API_TYPE": "minimax",
+        "MINIMAX_API_KEY": "test-key",
+        "MINIMAX_MODELS": '[{"displayName": "Custom", "name": "custom-model"}]',
+    }, clear=False)
+    def test_custom_minimax_models(self):
+        """Custom MINIMAX_MODELS env var overrides defaults."""
+        mod = self._reload_main()
+        self.assertEqual(len(mod.AVAILABLE_MODELS), 1)
+        self.assertEqual(mod.AVAILABLE_MODELS[0]["name"], "custom-model")
+
+
+class TestMiniMaxApiConfig(unittest.TestCase):
+    """Test that openai library is configured correctly for MiniMax."""
+
+    def _reload_main(self):
+        with patch.dict("sys.modules", {
+            "gpt_code_ui.kernel_program.main": MagicMock(APP_PORT=5010),
+            "pandas": MagicMock(),
+        }):
+            import gpt_code_ui.webapp.main as main_mod
+            importlib.reload(main_mod)
+            return main_mod
+
+    @patch.dict(os.environ, {
+        "OPENAI_API_TYPE": "minimax",
+        "MINIMAX_API_KEY": "test-minimax-key",
+    }, clear=False)
+    def test_minimax_sets_openai_api_type_to_open_ai(self):
+        """MiniMax provider sets openai.api_type to 'open_ai' for compatibility."""
+        import openai
+        env = os.environ.copy()
+        env.pop("OPENAI_API_BASE", None)
+        env["OPENAI_API_TYPE"] = "minimax"
+        env["MINIMAX_API_KEY"] = "test-minimax-key"
+        with patch.dict(os.environ, env):
+            self._reload_main()
+            self.assertEqual(openai.api_type, "open_ai")
+
+    @patch.dict(os.environ, {
+        "OPENAI_API_TYPE": "minimax",
+        "MINIMAX_API_KEY": "test-minimax-key",
+    }, clear=False)
+    def test_minimax_sets_default_base_url(self):
+        """MiniMax provider defaults to https://api.minimax.io/v1."""
+        import openai
+        env = os.environ.copy()
+        env.pop("OPENAI_API_BASE", None)
+        env["OPENAI_API_TYPE"] = "minimax"
+        env["MINIMAX_API_KEY"] = "test-minimax-key"
+        with patch.dict(os.environ, env):
+            self._reload_main()
+            self.assertEqual(openai.api_base, "https://api.minimax.io/v1")
+
+    @patch.dict(os.environ, {
+        "OPENAI_API_TYPE": "minimax",
+        "MINIMAX_API_KEY": "test-minimax-key",
+        "OPENAI_API_BASE": "https://custom.minimax.endpoint/v1",
+    }, clear=False)
+    def test_minimax_custom_base_url(self):
+        """Custom OPENAI_API_BASE overrides the MiniMax default."""
+        import openai
+        self._reload_main()
+        self.assertEqual(openai.api_base, "https://custom.minimax.endpoint/v1")
+
+    @patch.dict(os.environ, {
+        "OPENAI_API_TYPE": "minimax",
+        "MINIMAX_API_KEY": "test-minimax-key",
+    }, clear=False)
+    def test_minimax_uses_minimax_api_key(self):
+        """MiniMax provider uses MINIMAX_API_KEY for openai.api_key."""
+        import openai
+        self._reload_main()
+        self.assertEqual(openai.api_key, "test-minimax-key")
+
+
+class TestMiniMaxTemperatureClamping(unittest.TestCase):
+    """Test that temperature is clamped for MiniMax provider."""
+
+    def _reload_main(self):
+        with patch.dict("sys.modules", {
+            "gpt_code_ui.kernel_program.main": MagicMock(APP_PORT=5010),
+            "pandas": MagicMock(),
+        }):
+            import gpt_code_ui.webapp.main as main_mod
+            importlib.reload(main_mod)
+            return main_mod
+
+    @patch.dict(os.environ, {
+        "OPENAI_API_TYPE": "minimax",
+        "MINIMAX_API_KEY": "test-key",
+    }, clear=False)
+    @patch("openai.ChatCompletion.create")
+    def test_temperature_clamped_for_minimax(self, mock_create):
+        """Temperature is clamped to (0, 1] for MiniMax."""
+        mock_create.return_value = MagicMock(
+            choices=[MagicMock(
+                finish_reason="stop",
+                message=MagicMock(content="```python\nprint('hello')\n```")
+            )]
+        )
+        mod = self._reload_main()
+        import asyncio
+        loop = asyncio.new_event_loop()
+        loop.run_until_complete(mod.get_code("test prompt", model="MiniMax-M2.7"))
+        loop.close()
+
+        call_kwargs = mock_create.call_args[1]
+        temp = call_kwargs.get("temperature", None)
+        self.assertIsNotNone(temp)
+        self.assertGreater(temp, 0)
+        self.assertLessEqual(temp, 1.0)
+
+
+class TestMiniMaxModelRouting(unittest.TestCase):
+    """Test that MiniMax uses 'model' parameter (not 'deployment_id')."""
+
+    def _reload_main(self):
+        with patch.dict("sys.modules", {
+            "gpt_code_ui.kernel_program.main": MagicMock(APP_PORT=5010),
+            "pandas": MagicMock(),
+        }):
+            import gpt_code_ui.webapp.main as main_mod
+            importlib.reload(main_mod)
+            return main_mod
+
+    @patch.dict(os.environ, {
+        "OPENAI_API_TYPE": "minimax",
+        "MINIMAX_API_KEY": "test-key",
+    }, clear=False)
+    @patch("openai.ChatCompletion.create")
+    def test_minimax_uses_model_parameter(self, mock_create):
+        """MiniMax requests use 'model' key, not 'deployment_id'."""
+        mock_create.return_value = MagicMock(
+            choices=[MagicMock(
+                finish_reason="stop",
+                message=MagicMock(content="```python\nprint('hello')\n```")
+            )]
+        )
+        mod = self._reload_main()
+        import asyncio
+        loop = asyncio.new_event_loop()
+        loop.run_until_complete(mod.get_code("test prompt", model="MiniMax-M2.7"))
+        loop.close()
+
+        call_kwargs = mock_create.call_args[1]
+        self.assertEqual(call_kwargs["model"], "MiniMax-M2.7")
+        self.assertNotIn("deployment_id", call_kwargs)
+
+
+class TestInvalidProvider(unittest.TestCase):
+    """Test that invalid provider raises ValueError."""
+
+    def _reload_main(self):
+        with patch.dict("sys.modules", {
+            "gpt_code_ui.kernel_program.main": MagicMock(APP_PORT=5010),
+            "pandas": MagicMock(),
+        }):
+            import gpt_code_ui.webapp.main as main_mod
+            importlib.reload(main_mod)
+            return main_mod
+
+    @patch.dict(os.environ, {
+        "OPENAI_API_TYPE": "invalid_provider",
+    }, clear=False)
+    def test_invalid_provider_raises(self):
+        """Unknown OPENAI_API_TYPE raises ValueError."""
+        with self.assertRaises(ValueError):
+            self._reload_main()
+
+
+class TestEnvExampleFile(unittest.TestCase):
+    """Test that .env.minimax-example file is valid."""
+
+    def test_minimax_env_example_exists(self):
+        """The .env.minimax-example file exists."""
+        path = os.path.join(
+            os.path.dirname(__file__), "..", ".env.minimax-example"
+        )
+        self.assertTrue(os.path.exists(path))
+
+    def test_minimax_env_example_contains_key_vars(self):
+        """The .env.minimax-example file contains required configuration."""
+        path = os.path.join(
+            os.path.dirname(__file__), "..", ".env.minimax-example"
+        )
+        with open(path) as f:
+            content = f.read()
+        self.assertIn("MINIMAX_API_KEY", content)
+        self.assertIn("OPENAI_API_TYPE=minimax", content)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_minimax_provider.py
+++ b/tests/test_minimax_provider.py
@@ -72,7 +72,7 @@ class TestMiniMaxModels(unittest.TestCase):
         "MINIMAX_API_KEY": "test-key",
     }, clear=False)
     def test_default_minimax_models(self):
-        """Default MiniMax models include M2.7 and M2.7-highspeed."""
+        """Default MiniMax models include M3, M2.7 and M2.7-highspeed; M3 is first."""
         # Remove custom MINIMAX_MODELS if set
         env = os.environ.copy()
         env.pop("MINIMAX_MODELS", None)
@@ -81,8 +81,11 @@ class TestMiniMaxModels(unittest.TestCase):
         with patch.dict(os.environ, env):
             mod = self._reload_main()
             model_names = [m["name"] for m in mod.AVAILABLE_MODELS]
+            self.assertIn("MiniMax-M3", model_names)
             self.assertIn("MiniMax-M2.7", model_names)
             self.assertIn("MiniMax-M2.7-highspeed", model_names)
+            # M3 should be first (default)
+            self.assertEqual(model_names[0], "MiniMax-M3")
 
     @patch.dict(os.environ, {
         "OPENAI_API_TYPE": "minimax",


### PR DESCRIPTION
## Summary

Add [MiniMax AI](https://www.minimaxi.com/) as a third LLM provider alongside OpenAI and Azure OpenAI. MiniMax models (M3, M2.7, M2.7-highspeed) are supported via the OpenAI-compatible API, integrating cleanly with the existing `openai` library.

### Changes

- **Provider detection**: `OPENAI_API_TYPE=minimax` or auto-detection when `MINIMAX_API_KEY` is set without `OPENAI_API_KEY`
- **API routing**: MiniMax endpoint (`https://api.minimax.io/v1`) configured as the default base URL; uses standard `model` parameter
- **Temperature clamping**: Ensures temperature stays within MiniMax's supported range `(0, 1]`
- **Default models**: `MiniMax-M3` (default), `MiniMax-M2.7`, and `MiniMax-M2.7-highspeed`, customizable via `MINIMAX_MODELS` env var
- **Config template**: `.env.minimax-example` with all MiniMax configuration options
- **Documentation**: README section with setup instructions
- **Tests**: Unit tests + integration tests covering provider detection, model routing, API configuration, temperature clamping, and the M3 default

### About MiniMax-M3

`MiniMax-M3` is the latest MiniMax model: 512K context window, up to 128K output, and image input support. It is now the default; `MiniMax-M2.7` and `MiniMax-M2.7-highspeed` remain available for users who want to pin to the previous generation.

### Files Changed

| File | Description |
|------|-------------|
| `gpt_code_ui/webapp/main.py` | MiniMax provider detection, API config, model routing, temp clamping, M3 default |
| `.env.minimax-example` | MiniMax configuration template (M3 first in MINIMAX_MODELS example) |
| `README.md` | MiniMax setup documentation (mentions M3 default) |
| `tests/__init__.py` | Test package init |
| `tests/test_minimax_provider.py` | Unit tests (now asserts M3 is in defaults and first) |
| `tests/test_minimax_integration.py` | Integration tests (requires `MINIMAX_API_KEY`); covers M3, M2.7, M2.7-highspeed |

## Test Plan

- [x] All unit tests pass (`python -m unittest tests.test_minimax_provider`)
- [x] Integration tests cover M3 as the default
- [x] Existing OpenAI and Azure provider paths unchanged
- [ ] Manual test: set `OPENAI_API_TYPE=minimax` and run `gptcode`; verify M3 is the default model in the UI